### PR TITLE
Add a formatting script for GitHub Actions and add GitHub metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: godotengine
+custom: https://godotengine.org/donate

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug with the extension.
+title: ''
+labels: bug
+assignees: neikeq
+
+---
+
+<!--
+Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot-csharp-visualstudio/issues?q=is%3Aissue
+
+Only submit an issue if it is reproducible with the latest stable Godot version.
+-->
+
+**OS/device including version:**
+<!-- Specify GPU model and drivers if graphics-related. -->
+
+
+**Issue description:**
+<!-- What happened, what was expected, and what went wrong. -->
+
+
+**Screenshots of issue:**
+<!--
+This section is optional.
+Drag in an image, or post an image with a link in the form of:
+![Alt Text Here](https://pbs.twimg.com/media/DW5AJnZVAAM1805?format=jpg)
+-->

--- a/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature / Enhancement Request
+about: Adding new features or improving existing ones.
+title: ''
+labels: enhancement
+assignees: neikeq
+
+---
+
+<!--
+Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot-csharp-visualstudio/issues?q=is%3Aissue
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Lint extension
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq dos2unix recode
+          bash ./format.sh

--- a/GodotAddin/Debugging/GodotDebuggerEngine.cs
+++ b/GodotAddin/Debugging/GodotDebuggerEngine.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
 using Mono.Debugging.Client;

--- a/GodotAddin/Debugging/GodotDebuggerSession.cs
+++ b/GodotAddin/Debugging/GodotDebuggerSession.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;

--- a/GodotAddin/Debugging/GodotDebuggerStartInfo.cs
+++ b/GodotAddin/Debugging/GodotDebuggerStartInfo.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Debugging.Soft;
+using Mono.Debugging.Soft;
 
 namespace GodotAddin.Debugging
 {

--- a/GodotAddin/Debugging/GodotExecutionCommand.cs
+++ b/GodotAddin/Debugging/GodotExecutionCommand.cs
@@ -1,4 +1,4 @@
-﻿using GodotTools.IdeMessaging;
+using GodotTools.IdeMessaging;
 using MonoDevelop.Core.Execution;
 
 namespace GodotAddin.Debugging

--- a/GodotAddin/Debugging/GodotSoftDebuggerArgs.cs
+++ b/GodotAddin/Debugging/GodotSoftDebuggerArgs.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Mono.Debugging.Soft;
 
 namespace GodotAddin.Debugging

--- a/GodotAddin/GodotMessaging/MessageHandler.cs
+++ b/GodotAddin/GodotMessaging/MessageHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using GodotTools.IdeMessaging;

--- a/GodotAddin/GodotOptionsPanel.cs
+++ b/GodotAddin/GodotOptionsPanel.cs
@@ -1,4 +1,4 @@
-﻿using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Components;
 using MonoDevelop.Core;
 

--- a/GodotAddin/GodotProjectExtension.cs
+++ b/GodotAddin/GodotProjectExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/GodotAddin/MonoDevelopLogger.cs
+++ b/GodotAddin/MonoDevelopLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MonoDevelop.Core;
 
 namespace GodotAddin

--- a/GodotAddin/Properties/AddinInfo.cs
+++ b/GodotAddin/Properties/AddinInfo.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Addins;
+using Mono.Addins;
 using Mono.Addins.Description;
 
 [assembly: Addin(

--- a/GodotAddin/Properties/Manifest.addin.xml
+++ b/GodotAddin/Properties/Manifest.addin.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
     <Extension path="/MonoDevelop/Debugging/DebuggerEngines">
         <DebuggerEngine

--- a/GodotAddin/Settings.cs
+++ b/GodotAddin/Settings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using MonoDevelop.Core;

--- a/GodotAddin/Utils/ExtensionMethods.cs
+++ b/GodotAddin/Utils/ExtensionMethods.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 
 namespace GodotAddin.Utils

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+IFS=$'\n\t'
+
+# Loops through all text files tracked by Git.
+git grep -zIl '' |
+while IFS= read -rd '' f; do
+    # Exclude csproj and hdr files.
+    if [[ "$f" == *"csproj" ]]; then
+        continue
+    elif [[ "$f" == *"hdr" ]]; then
+        continue
+    fi
+    # Ensures that files are UTF-8 formatted.
+    recode UTF-8 "$f" 2> /dev/null
+    # Ensures that files have LF line endings.
+    dos2unix "$f" 2> /dev/null
+    # Ensures that files do not contain a BOM.
+    sed -i '1s/^\xEF\xBB\xBF//' "$f"
+    # Ensures that files end with newline characters.
+    tail -c1 < "$f" | read -r _ || echo >> "$f";
+    # Remove trailing space characters.
+    sed -z -i 's/\x20\x0A/\x0A/g' "$f"
+done
+
+git diff > patch.patch
+FILESIZE="$(stat -c%s patch.patch)"
+MAXSIZE=5
+
+# If no patch has been generated all is OK, clean up, and exit.
+if (( FILESIZE < MAXSIZE )); then
+    printf "Files in this commit comply with the formatting rules.\n"
+    rm -f patch.patch
+    exit 0
+fi
+
+# A patch has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the formatting rules:\n\n"
+cat patch.patch
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+rm -f patch.patch
+exit 1


### PR DESCRIPTION
The formatting script is `format.sh`, and the file which causes it to be ran automatically on GitHub Actions is
`.github/workflows/ci.yml`. The metadata mentioned in the title includes issue templates and funding information.

The CI won't run until it's in the repository, so there is no CI check for this PR itself.